### PR TITLE
Update - Retrait du bouton LinkedIn Jack

### DIFF
--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -43,7 +43,6 @@
     {
       name: "Jack William Beavan",
       title: "Consultant UX",
-      linkedIn: "https://www.linkedin.com/in/jack-william-beavan-2a893714b/",
       img: "jack.jpg"
     },
     {


### PR DESCRIPTION
Jack n'a plus de profil LinkedIn donc j'ai enlevé le bouton, sur la page "À propos".